### PR TITLE
Redirect favicon.ico requests

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -103,6 +103,10 @@ func get(letterPath string) (Letters, error) {
 func main() {
 	flag.Parse()
 
+	http.HandleFunc("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, TINYLETTER+r.URL.Path, 301)
+	})
+
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		letters, err := get(r.URL.Path)
 		if err != nil {


### PR DESCRIPTION
Adds a handler for requests to `/favicon.ico`.

### Motivation

+ Requests to `tl-feed` from the browser request `favicon.ico` in the background; the forwarded request to `/favicon.ico/archive` logs 404s.
+ Adds a favicon in the browser :)

### Testing

+ Confirmed that requests to `http://localhost:8080/favicon.ico` are redirected to `https://tinyletter.com/favicon.ico`, and that the redirect is cached (Chrome 80) when the server is offline.
+ Confirmed that `http://localhost:8080/some-newsletter-id` serves the newsletter RSS as before, now with the TinyLetter favicon in the browser.

Ran `go fmt`.